### PR TITLE
README.md: fix markdown formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
-#MinnowBoard.org Hardware Design Files
+# MinnowBoard.org Hardware Design Files
 
-##PURPOSE:
-The /design-files repository is the target folder for official MinnowBoard.org hardware design files. Such files may include: design schematics, printed circult board (PCB) design database(s), PCB gerber files, PCB manufacturing files, bill of materials (BOM), 3D models, mechanical step files, thermal models, multiple versions for different design tools, some firmware, CPLD code, FPGA code, etc. 
+## PURPOSE:
+The `/design-files` repository is the target folder for official [MinnowBoard.org] hardware design files. Such files may include: design schematics, printed circult board (PCB) design database(s), PCB gerber files, PCB manufacturing files, bill of materials (BOM), 3D models, mechanical step files, thermal models, multiple versions for different design tools, some firmware, CPLD code, FPGA code, etc. 
 
-##LICENSING:
-*All files are subject to the associated licensing stated within each directory.* MinnowBoard.org is founded with a goal for full open source, defaulting to [Creative Commons Attribution 4.0](https://creativecommons.org/licenses/by/4.0/) for hardware and MIT license for code....to let developers take the files and develop without licensing burden. We stick to this as much as possible. For a deep read, see MinnowBoard.org [Terms of Service and Intellectual Property Rights](https://www.minnowboard.org/terms-of-service). If you have questions, [Contact us.](https://www.minnowboard.org/help)
+## LICENSING:
+*All files are subject to the associated licensing stated within each directory.* [MinnowBoard.org] is founded with a goal for full open source, defaulting to [Creative Commons Attribution 4.0](https://creativecommons.org/licenses/by/4.0/) for hardware and [MIT](https://opensource.org/licenses/MIT) license for code....to let developers take the files and develop without licensing burden. We stick to this as much as possible. For a deep read, see MinnowBoard.org [Terms of Service and Intellectual Property Rights](https://www.minnowboard.org/terms-of-service). If you have questions, [Contact us.](https://www.minnowboard.org/help)
 
-##SAFETY AND REGULATORY:
-###The Disclaimer:
+## SAFETY AND REGULATORY:
+### The Disclaimer:
 >The files for MinnowBoard reference designs do not guarantee regulatory compliance.  The developer is responsible for all aspects of regulatory evaluation, reporting and registration when modifying and/or incorporating any element of these reference designs into a host device.
 
-###What it means:
+### What it means:
 Our goal is for developers to easily prototype their innovative idea with optimized MinnowBoard hardware/software/firmware, but this isn't the end goal. We ALSO want to enable developers to easily PRODUCTIZE and bring their idea to market. Such a product must meet the legal, safety, regulatory, commerce, etc, requirements for the target distribution geography. Thus, we spend extra time and effort to design our developer boards to already meet the electrical, EMI/EMC, safety, etc requirements for most global countries, and further, we test to those standards in licensed labs. We will often share the reports as reference baseline for developers considering design modifications. 
 >Example: The current MinnowBoard target for EMI/EMC emissions in the United States is open board FCC Title 47 Part 15 Class B, which generally allows distribution to both commercial and residential environments. (Most developer boards are not even close to this).
 
-*The Takeaway:* We do our best to minimize the effort required to achieve regulatory compliance on developer production design derivatives, but you are responsible for all aspects of regulatory compliance for your modification designs. 
+*The Takeaway:* We do our best to minimize the effort required to achieve regulatory compliance on developer production design derivatives, but you are responsible for all aspects of regulatory compliance for your modification designs.
+
+[MinnowBoard.org]: https://minnowboard.org/


### PR DESCRIPTION
The markdown formatting of the README.md file was slightly incorrect causing the rendering to be broken. This fixes the formatting and also adds a couple of hyperlinks.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>